### PR TITLE
Fix regression compilation ffmpeg_intgr.c to support ffmpeg 5

### DIFF
--- a/src/lib_ccx/ffmpeg_intgr.c
+++ b/src/lib_ccx/ffmpeg_intgr.c
@@ -105,7 +105,7 @@ void *init_ffmpeg(const char *path)
 		goto fail;
 	}
 	stream_index = ret;
-	ctx->dec_ctx = ctx->ifmt->streams[stream_index]->codec;
+	ctx->dec_ctx = ctx->ifmt->streams[stream_index]->codecpar;
 	ctx->stream_index = stream_index;
 	ret = avcodec_open2(ctx->dec_ctx, dec, NULL);
 	if (ret < 0)
@@ -149,7 +149,7 @@ int ff_get_ccframe(void *arg, unsigned char *data, int maxlen)
 		return AVERROR(EAGAIN);
 	}
 
-	avcodec_send_packet(ctx->codec_ctx, &ctx->packet);
+	avcodec_send_packet(ctx->dec_ctx, &packet);
 	ret = avcodec_receive_frame(ctx->dec_ctx, ctx->frame);
 	if (ret < 0)
 	{


### PR DESCRIPTION
Fix regression bug for compiling with ENABLE_FFMPEG and ffmpeg 5, introduced in https://github.com/CCExtractor/ccextractor/issues/1418

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
